### PR TITLE
Added error client event

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,5 +32,9 @@ client.on("ready", () => {
 client.on("message", msg => {
   message.handleCommand(msg, client)
   filter.handler(msg, client)
+})
 
+client.on("error", error => {
+  console.log("[ERROR] Discord.js client error, outputting to console...")
+  console.log(error)
 })


### PR DESCRIPTION
Spontaneous crashes were occurring due to the `error` client event missing, this pull request adds it. When more robust error handling is added (#1) this event should be included.